### PR TITLE
Startup error fix

### DIFF
--- a/orm/model.lua
+++ b/orm/model.lua
@@ -26,7 +26,7 @@ POSTGRESQL = "postgresql"
 ------------------------------------------------------------------------------
 
 if not DB then
-    BACKTRACE(INFO, "Cna't find global database settings variable 'DB'")
+    print("[SQL:Startup] Can't find global database settings variable 'DB'. Creating empty one.")
     DB = {}
 end
 


### PR DESCRIPTION
Error: 
```
> require("orm.model")
./orm/class/global.lua:29: attempt to index global 'DB' (a nil value)
stack traceback:
	./orm/class/global.lua:29: in function 'BACKTRACE'
	./orm/model.lua:29: in main chunk
	[C]: in function 'require'
	stdin:1: in main chunk
	[C]: ?
```

Now, it will be:
```
> require("orm.model")
[SQL:Startup] Can't find global database settings variable 'DB'. Creating empty one.
```

I didn't move it to BACKTRACE because it used only on startup.