### PR TITLE
Fix table reference in field type instances

### DIFF
--- a/orm/class/fields.lua
+++ b/orm/class/fields.lua
@@ -100,7 +100,15 @@ local Field = {
                 }
 
                 -- Set Default settings
-                new_self.settings = new_self.field.settings
+
+                --
+                -- The content of the settings table must be copied because trying to copy a table
+                -- directly will result in a reference to the original table, thus all
+                -- instances of the same field type would have the same settings table.
+                --
+                for index, setting in pairs(new_self.field.settings) do
+                  new_self.settings[index] = setting
+                end
 
                 -- Set settings for column
                 if args.max_length then


### PR DESCRIPTION
Fixed the table reference of the settings table in the field type instances.
Now it is possible to have an individual configuration for each instance of a field type which is very important for multiple foreign keys in the same table.
This fix requires the settings table to be a one dimensional table (which it currently is).

This change should also fix #18.