### PR TITLE
replace table.getn()

### DIFF
--- a/orm/class/query_list.lua
+++ b/orm/class/query_list.lua
@@ -69,7 +69,7 @@ function QueryList(own_table, rows)
 
         -- Get count of values in stack
         count = function (self)
-            return table.getn(self._stack)
+            return #self._stack
         end,
 
         -- Remove from database all elements from stack

--- a/orm/class/select.lua
+++ b/orm/class/select.lua
@@ -78,7 +78,7 @@ local Select = function(own_table)
             elseif colname:endswith(IN) or colname:endswith(NOT_IN) then
                 rule = colname:endswith(IN) and IN or NOT_IN
 
-                if type(value) == "table" and table.getn(value) > 0 then
+                if type(value) == "table" and #value > 0 then
                     colname = string.cutend(colname, rule)
                     table_column = self.own_table:get_column(colname)
                     _in = {}
@@ -291,7 +291,7 @@ local Select = function(own_table)
             _select = "SELECT " .. including
 
             -- Add join rules
-            if table.getn(self._rules.columns.join) > 0 then
+            if #self._rules.columns.join > 0 then
                 local unique_tables = { self.own_table }
                 local join_tables = {}
                 local left_table, right_table
@@ -315,7 +315,7 @@ local Select = function(own_table)
             end
 
             -- Check aggregators in select
-            if table.getn(self._rules.columns.include) > 0 then
+            if #self._rules.columns.include > 0 then
                 local aggregators = {}
                 local aggregator, as
 
@@ -341,7 +341,7 @@ local Select = function(own_table)
             end
 
             -- Build GROUP BY
-            if table.getn(self._rules.group) > 0 then
+            if #self._rules.group > 0 then
                 rule = self:_update_col_names(self._rules.group)
                 rule = table.join(rule)
                 _select = _select .. " \nGROUP BY " .. rule
@@ -354,7 +354,7 @@ local Select = function(own_table)
             end
 
             -- Build ORDER BY
-            if table.getn(self._rules.order) > 0 then
+            if #self._rules.order > 0 then
                 rule = self:_update_col_names(self._rules.order)
                 rule = table.join(rule)
                 _select = _select .. " \nORDER BY " .. rule

--- a/test/luaunit.lua
+++ b/test/luaunit.lua
@@ -113,7 +113,7 @@ function orderedNext(t, state)
     end
     -- fetch the next value
     key = nil
-    for i = 1,table.getn(t.__orderedIndex) do
+    for i = 1,#t.__orderedIndex do
         if t.__orderedIndex[i] == state then
             key = t.__orderedIndex[i+1]
         end
@@ -178,7 +178,7 @@ UnitResult = { -- class
     end
 
     function UnitResult:displayFailedTests()
-        if table.getn( self.errorList ) == 0 then return end
+        if #self.errorList == 0 then return end
         print("Failed tests:")
         print("-------------")
         table.foreachi( self.errorList, self.displayOneFailedTest )
@@ -260,7 +260,7 @@ LuaUnit = {
     function LuaUnit.strip_luaunit_stack(stack_trace)
         stack_list = LuaUnit.strsplit( "\n", stack_trace )
         strip_end = nil
-        for i = table.getn(stack_list),1,-1 do
+        for i = #stack_list,1,-1 do
             -- a bit rude but it works !
             if string.find(stack_list[i],"[C]: in function `xpcall'",0,true)
                 then


### PR DESCRIPTION
`table.getn()` was removed in lua 5.2. Replaced it with `#`. Tested on lua 5.3 and seems to be working fine.